### PR TITLE
Fix: custom script not triggered on periodic IP check when IP changes

### DIFF
--- a/MenuBarIP/MenuBarIP/Services/NetworkService.swift
+++ b/MenuBarIP/MenuBarIP/Services/NetworkService.swift
@@ -210,6 +210,7 @@ class NetworkService: ApiCallable, NetworkServiceType {
                 
                 try? await Task.sleep(nanoseconds:UInt64(self.appState.userData.intervalBetweenChecks) * Constants.secondInNanoseconds)
                 
+                let prevPublicIp = self.appState.network.publicIp
                 let publicIp = await fetchPublicIpAsync()
                 
                 await updateStatusAsync(update: builder
@@ -217,6 +218,7 @@ class NetworkService: ApiCallable, NetworkServiceType {
                     .build())
                 
                 writeLog(publicIp: publicIp)
+                executeScript(prevPublicIp: prevPublicIp, publicIp: publicIp)
             }
         }
     }


### PR DESCRIPTION
## Problem

When a user's public IP address changes and is detected by the **periodic IP check** (rather than by a network state change), the custom script is **not executed**.

This is because `startPeriodicIpCheck()` in `NetworkService.swift` only updates the public IP status and writes a log entry, but never calls `executeScript()`.

As a result, users who rely on periodic IP checks (especially when the network connection state does not change, e.g. behind a router that transparently switches ISPs or VPN tunnels) will never have their configured scripts triggered on IP changes.

## Root Cause

The `startPeriodicIpCheck()` method captures and updates the public IP but does not invoke `executeScript(prevPublicIp:publicIp:)`, unlike `refreshIpAddressesAsync()` which does call it correctly.

## Fix

Two lines added to `startPeriodicIpCheck()` in `NetworkService.swift`:

1. **Capture the previous public IP** before fetching the new one:
```swift
let prevPublicIp = self.appState.network.publicIp
```

2. **Call `executeScript()` after updating status and writing the log**:
```swift
executeScript(prevPublicIp: prevPublicIp, publicIp: publicIp)
```

The existing `executeScript()` method already handles all the necessary guards:
- Checks if `runScript` is enabled in user settings
- Verifies that both previous and current IPs exist
- Only triggers the script when the IP address has actually changed

This ensures consistency with the `refreshIpAddressesAsync()` code path and completes the script-triggering behavior for all IP detection mechanisms.

## Testing

- Configured a custom script (shell script) to kill an application and send a macOS notification on IP change
- Enabled periodic IP check with a 10-second interval
- Switched the public IP (via VPN/router) **without** changing network connection state
- Verified the custom script was executed within 10 seconds of the IP change
- Verified the script received the new public IP as its first argument
